### PR TITLE
fix team creation

### DIFF
--- a/src/components/Team/CreateTeam.js
+++ b/src/components/Team/CreateTeam.js
@@ -38,10 +38,9 @@ class CreateTeam extends React.Component {
       eventId: events.selected.id,
     })
       .then(
-        async (resp) => {
-          const team = await resp.json();
+        async () => {
           this.setState({ loading: false });
-          teams.append(team);
+          teams.fetchList();
         },
         (error) => {
           this.setState({ error: error.body.message, loading: false });

--- a/src/stores/teams.js
+++ b/src/stores/teams.js
@@ -51,10 +51,6 @@ class Teams {
       );
   }
 
-  append(team) {
-    this.list.push(team);
-  }
-
   apiFail(error) {
     this.error = error.body.message;
     this.fetching = false;
@@ -74,7 +70,6 @@ export default decorate(Teams, {
   fetched: computed,
   loading: computed,
   fetchList: action.bound,
-  append: action.bound,
   apiFail: action.bound,
   clear: action.bound,
 });


### PR DESCRIPTION
The backend doesn't return the full team object when creating team.  
We need to refetch the list. (or we could have gotten the id, get the individual team and then manually add it to the list)